### PR TITLE
Update `analysis-path` to match subdirectory name

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,7 +6,7 @@ config-version: 2
 profile: 'bdc-dbt-enablement'
 
 model-paths: ["models"]
-analysis-paths: ["analyses"]
+analysis-paths: ["analysis"]
 test-paths: ["tests"]
 seed-paths: ["seeds"]
 macro-paths: ["macros"]


### PR DESCRIPTION
The `analysis-paths` in `dbt_project.yml` points to `analyses`, but this project uses a folder called `analysis`. Updated to point to the existing folder.